### PR TITLE
Fix "Grades not submitted" error

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,5 +1,4 @@
 LAB_DIRECTORY = "lab4"
-NUM_GRADES = 3
 WORKING_DIRECTORY = "WD"
 FILE_NAME = "lab4.py"
 CSV_FILE_NAME = "gradeHelper.csv"

--- a/gradehelper.py
+++ b/gradehelper.py
@@ -159,6 +159,7 @@ class Window(QtWidgets.QMainWindow):
         else:
             create_message_pop_up_box("Grades have not been submitted yet")
         self._program_started = False
+        self._current_student_grades_submitted = False
 
     # function to clear fields in the textboxes
     def clear_fields(self):


### PR DESCRIPTION
Resolves #25 
Previously, the "Grades not submitted" error only pops up for the first student if user continues without submitting the grade for the student and does not appear afterwards. Now it pops up whenever a student's grades is not submitted and moving past the student is attempted. 